### PR TITLE
Fix CSS stylesheet link typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
This PR fixes the critical styling bug in the World Clock application.

## Changes
- Fixed typo in index.html line 7: changed href from styls.css to styles.css

## Testing
- CSS now loads correctly and the page displays with proper styling

Fixes #11